### PR TITLE
fix: revert withastro/action to v6, v7 does not exist

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install, build
-        uses: withastro/action@v7
+        uses: withastro/action@v6
         
   deploy:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'


### PR DESCRIPTION
v6.1.2 is the latest release of withastro/action; there is no v7 tag, so the pipeline was failing to resolve the action. The action isn't strictly versioned to Astro majors, v6 already supports Astro 7.